### PR TITLE
Fixed deprecated import of SafeConfigParser to ConfigParser

### DIFF
--- a/roguehostapd/config/hostapdconfig.py
+++ b/roguehostapd/config/hostapdconfig.py
@@ -6,17 +6,14 @@ import re
 import collections
 import os
 import json
-try:
-    from configparser import SafeConfigParser  # Python 3
-except ImportError:
-    from ConfigParser import SafeConfigParser  # Python 2
+from configparser import ConfigParser
 
 
 def get_default_settings():
     """
     Get the project default settings
     """
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read(ROGUEHOSTAPD_DEFAULT_CONFIGPATH)
     default_settings = collections.defaultdict()
     for section in config.sections():


### PR DESCRIPTION
SafeConfigParser was deprecated and eventually removed in Python 3. It’s now called ConfigParser in Python 3.